### PR TITLE
Complete task even if Less error occurs

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -39,8 +39,12 @@ module.exports = function(grunt) {
         helperOptions = _.extend({filename: srcFile}, options);
         sourceCode = grunt.file.read(srcFile);
 
-        compileLess(sourceCode, helperOptions, function(css) {
-          nextConcat(null, css);
+        compileLess(sourceCode, helperOptions, function(css, err) {
+          if(!err) {
+            nextConcat(null, css);
+          } else {
+            done();
+          }
         });
       }, function(err, css) {
         grunt.file.write(file.dest, css.join('\n') || '');
@@ -68,9 +72,10 @@ module.exports = function(grunt) {
 
       try {
         var css = tree.toCSS();
-        callback(css);
+        callback(css, null);
       } catch (e) {
         lessError(e);
+        callback(css, true);
       }
     });
   };


### PR DESCRIPTION
Here is the same pull request now that the tasks have been split out into different repositories.

The changes that I have made allow the async task to complete properly even if there is an error so that grunt can continue to watch your less files for subsequent changes.

Let me know if anything needs to be refactored to tie in with task guidelines etc.
