### PR TITLE
extend options with dumpLineNumbers

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
   var less = require('less');
 
   var lessOptions = {
-    parse: ['paths', 'optimization', 'filename', 'strictImports'],
+    parse: ['paths', 'optimization', 'filename', 'strictImports', 'dumpLineNumbers'],
     render: ['compress', 'yuicompress']
   };
 


### PR DESCRIPTION
Extending options with the dumpLineNumbers will enable debugging in dev env.

```
  less: {
      development: {
          options: {
              'dumpLineNumbers': 'all' 
          },
          files: {
              "result.css": "source.less"
          }
      }
  }
```

will output in css:

/\* line LINE_NUMBER, PATH_TO_LESS_SOURCE */
@media -sass-debug-info{filename{font-family:"PATH_TO_LESS_SOURCE";}line{font-family:"LINE_NUMBER";}}

-sass-debug-info is now supported in chrome dev tools(experimental) and in extensions for ff and chrome. 

The dumpLineNumbers option accepts following values: comments/mediaquery/all.
