### PR TITLE
Gracefully handle no sources

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,6 +62,8 @@ module.exports = function(grunt) {
           'tmp/yuicompress.css': ['test/fixtures/style.less']
         }
       },
+      nofiles: {
+      },
       nomatchedfiles: {
         files: { "tmp/nomatchedfiles.css" : 'test/nonexistent/*.less' }
       }

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -24,6 +24,10 @@ module.exports = function(grunt) {
     var options = this.options();
     grunt.verbose.writeflags(options, 'Options');
 
+    if (this.files.length < 1) {
+      grunt.log.warn('Destination not written because no source files were provided.');
+    }
+
     grunt.util.async.forEachSeries(this.files, function(f, nextFileObj) {
       var destFile = f.dest;
 
@@ -38,6 +42,10 @@ module.exports = function(grunt) {
       });
 
       if (files.length === 0) {
+        if (f.src.length < 1) {
+          grunt.log.warn('Destination not written because no source files were found.');
+        }
+
         // No src files, goto next target. Warn would have been issued above.
         return nextFileObj();
       }
@@ -47,7 +55,7 @@ module.exports = function(grunt) {
         compileLess(file, options, function(css, err) {
           if (!err) {
             compiled.push(css);
-            next(null);
+            next();
           } else {
             nextFileObj(false);
           }


### PR DESCRIPTION
Fixes #38

Also prints warnings when no sources are provided or matched rather than silently continuing.
