### PR TITLE
Fixed Grunt shutdown on unhandled error

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
             compiled.push(css);
             next();
           } else {
-            nextFileObj(false);
+            nextFileObj(err);
           }
         });
       }, function() {


### PR DESCRIPTION
Since changed `async.forEach` to `async.forEachSeries`. There starts an infinite loop when compilation error happens, but the infinite loop ends right on the first accessing of `f.dest` beacuse `f` is `undefined`.

`nextFileObj(false);` in `forEachSeries` does not end the loop (opposite to `forEach` behavior), instead it continues it.

Passing `err` object instead of `false` does well. Automated compilation with watch systems cannot work well with of this bug.
