### PR TITLE
NAN workaround

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
 
   var lessOptions = {
     parse: ['paths', 'optimization', 'filename', 'strictImports', 'dumpLineNumbers'],
-    render: ['compress', 'yuicompress', 'ieCompat']
+    render: ['compress', 'yuicompress', 'ieCompat', 'strictMath']
   };
 
   grunt.registerMultiTask('less', 'Compile LESS files to CSS', function() {
@@ -74,6 +74,9 @@ module.exports = function(grunt) {
   });
 
   var compileLess = function(srcFile, options, callback) {
+    if (!options.hasOwnProperty('strictMath')) {
+      options = grunt.util._.extend({strictMath: false}, options);
+    }
     options = grunt.util._.extend({filename: srcFile}, options);
     options.paths = options.paths || [path.dirname(srcFile)];
 


### PR DESCRIPTION
I think we need to set the strictMath property (less 1.4). If this property is missing in a gruntfile then the less tree/rule.js (https://github.com/cloudhead/less.js/blob/master/lib/less/tree/rule.js) env.strictMath returns undefined. In the line 38 there is a condition (this.name === "font" && env.strictMath === false) which handle(bypass) CSS font rule. 

When we extend the lessOptions render property, we'll be able to set the strictMath option in the gruntfile. 

While the strictMath mode is a new feature and not so popular we have to handle a default value in a task in my opinion. That's why there is a check for a property. 
