### PR TITLE
should not display no files warning in default log

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -28,7 +28,7 @@ module.exports = function(grunt) {
     grunt.verbose.writeflags(options, 'Options');
 
     if (this.files.length < 1) {
-      grunt.log.warn('Destination not written because no source files were provided.');
+      grunt.verbose.warn('Destination not written because no source files were provided.');
     }
 
     grunt.util.async.forEachSeries(this.files, function(f, nextFileObj) {


### PR DESCRIPTION
There should not display a warning when there is no less file, just like what grunt-contrib-stylus did.

https://github.com/gruntjs/grunt-contrib-stylus/blob/master/tasks/stylus.js#L29
