### PR TITLE
Output the file currently being compiled when we encounter an error.

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -96,7 +96,7 @@ module.exports = function(grunt) {
 
     parser.parse(srcCode, function(parse_err, tree) {
       if (parse_err) {
-        lessError(parse_err);
+        lessError(parse_err, srcFile);
         callback('',true);
       }
 
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
         css = minify(tree, grunt.util._.pick(options, lessOptions.render));
         callback(css, null);
       } catch (e) {
-        lessError(e);
+        lessError(e, srcFile);
         callback(css, true);
       }
     });
@@ -115,11 +115,11 @@ module.exports = function(grunt) {
     return e.filename + ': ' + pos + ' ' + e.message;
   };
 
-  var lessError = function(e) {
+  var lessError = function(e, file) {
     var message = less.formatError ? less.formatError(e) : formatLessError(e);
 
     grunt.log.error(message);
-    grunt.fail.warn('Error compiling LESS.');
+    grunt.fail.warn('Error compiling '+file);
   };
 
   var minify = function (tree, options) {


### PR DESCRIPTION
I just spent four hours completely restructuring a large codebase trying to chase down the source of a missing variable.  All that could have taken just five minutes if the task had reported what file it was compiling when it hit the error.  I kept thinking I had some weird race condition because I was barking up the totally wrong tree. :)
