### PR TITLE
Support "strictUnits" option

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
 
   var lessOptions = {
     parse: ['paths', 'optimization', 'filename', 'strictImports', 'syncImport', 'dumpLineNumbers', 'relativeUrls', 'rootpath'],
-    render: ['compress', 'yuicompress', 'ieCompat', 'strictMath']
+    render: ['compress', 'yuicompress', 'ieCompat', 'strictMath', 'strictUnits']
   };
 
   grunt.registerMultiTask('less', 'Compile LESS files to CSS', function() {


### PR DESCRIPTION
This adds "strictUnits" to the render options whitelist.

I wonder if, instead of this whitelist of options, it wouldn't be better to just send them all through. That way, if less updates its options or adds new ones, they'll be immediately available to the grunt task.
