### PR TITLE
Upgrade to less 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "less": "~1.4.0",
+    "less": "~1.5.0",
     "grunt-lib-contrib": "~0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Less 1.5.0 is out and it would be great to get a release with it for https://github.com/less/less.js/issues/1432 which can cause less compilation to intermittently fail.
