### PR TITLE
Allow custom functions return types defined within less

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ Type: `Object`
 
 Default: none
 
-Define custom functions to be available within your LESS stylesheets. The function's name must be lowercase and
-return a primitive type (not an object or array). In the function definition, the first argument is the less
-object, and subsequent arguments are from the less function call. Values passed to the function are not simple
-primitive types, rather types defined within less. See the LESS documentation for more information on the available types.
+Define custom functions to be available within your LESS stylesheets. The function's name must be lowercase.
+In the definition, the first argument is the less object, and subsequent arguments are from the less function call.
+Values passed to the function are types defined within less, the return value may be either one of them or primitive.
+See the LESS documentation for more information on the available types.
 
 #### report
 Choices: `'min'`, `'gzip'`  
@@ -242,4 +242,4 @@ less: {
 
 Task submitted by [Tyler Kellen](http://goingslowly.com/)
 
-*This file was generated on Sat Mar 15 2014 15:38:05.*
+*This file was generated on Tue Mar 18 2014 20:46:10.*

--- a/docs/less-options.md
+++ b/docs/less-options.md
@@ -95,10 +95,10 @@ Type: `Object`
 
 Default: none
 
-Define custom functions to be available within your LESS stylesheets. The function's name must be lowercase and
-return a primitive type (not an object or array). In the function definition, the first argument is the less
-object, and subsequent arguments are from the less function call. Values passed to the function are not simple
-primitive types, rather types defined within less. See the LESS documentation for more information on the available types.
+Define custom functions to be available within your LESS stylesheets. The function's name must be lowercase.
+In the definition, the first argument is the less object, and subsequent arguments are from the less function call.
+Values passed to the function are types defined within less, the return value may be either one of them or primitive.
+See the LESS documentation for more information on the available types.
 
 ## report
 Choices: `'min'`, `'gzip'`  

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -129,7 +129,8 @@ module.exports = function(grunt) {
           less.tree.functions[name.toLowerCase()] = function() {
             var args = [].slice.call(arguments);
             args.unshift(less);
-            return new less.tree.Anonymous(options.customFunctions[name].apply(this, args));
+            var res = options.customFunctions[name].apply(this, args);
+            return typeof res === "object" ? res : new less.tree.Anonymous(res);
           };
         });
       }


### PR DESCRIPTION
It's usefull to allow custom functions to return not only primitive types. `less.tree.Anonymous` does not allow further processing of returned value. For example I wrote function `image-width` and want to set `margin-left: image-width('kitty.jpg') / 2`.

It could be achived by hardcoding allowed types (according to [parser](https://github.com/less/less.js/blob/master/lib/less/parser.js#L1106) [rules](https://github.com/less/less.js/blob/master/lib/less/parser.js#L719)) like this:

```
      less.tree.functions[name.toLowerCase()] = function() {
        var args = [].slice.call(arguments);
        args.unshift(less);
        var res = options.customFunctions[name].apply(this, args);
        return ['Dimension', 'Color', 'URL', 'Quoted'].some(function (type) {
          return res instanceof less.tree[type];
        }) ? res : new less.tree.Anonymous(res);
      };
```

Though it's much simplier (and acceptable I believe) to test existence of `toCSS`/`genCSS` methods.
