### PR TITLE
Add space between option type and default, that was removed in #95.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,24 +30,28 @@ Task targets, files and options may be specified according to the grunt [Configu
 
 #### paths
 Type: `String|Array`
+
 Default: Directory of input file.
 
 Specifies directories to scan for @import directives when parsing. Default value is the directory of the source, which is probably what you want.
 
 #### compress
 Type: `Boolean`
+
 Default: `false`
 
 Compress output by removing some whitespaces.
 
 #### cleancss
 Type: `Boolean`
+
 Default: `false`
 
 Compress output using [clean-css](https://npmjs.org/package/clean-css).
 
 #### ieCompat
 Type: `Boolean`
+
 Default: `true`
 
 Enforce the css output is compatible with Internet Explorer 8.
@@ -56,36 +60,42 @@ For example, the [data-uri](https://github.com/cloudhead/less.js/pull/1086) func
 
 #### optimization
 Type: `Integer`
+
 Default: `null`
 
 Set the parser's optimization level. The lower the number, the less nodes it will create in the tree. This could matter for debugging, or if you want to access the individual nodes in the tree.
 
 #### strictImports
 Type: `Boolean`
+
 Default: `false`
 
 Force evaluation of imports.
 
 #### strictMath
 Type: `Boolean`
+
 Default: `false`
 
 When enabled, math is required to be in parenthesis.
 
 #### strictUnits
 Type: `Boolean`
+
 Default: `false`
 
 When enabled, less will validate the units used (e.g. 4px/2px = 2, not 2px and 4em/2px throws an error).
 
 #### syncImport
 Type: `Boolean`
+
 Default: `false`
 
 Read @import'ed files synchronously from disk.
 
 #### dumpLineNumbers
 Type: `String`
+
 Default: `false`
 
 Configures -sass-debug-info support.
@@ -94,12 +104,14 @@ Accepts following values: `comments`, `mediaquery`, `all`.
 
 #### relativeUrls
 Type: `Boolean`
+
 Default: `false`
 
 Rewrite urls to be relative. false: do not modify urls.
 
 #### customFunctions
 Type: `Object`
+
 Default: none
 
 Define custom functions to be available within your LESS stylesheets. The function's name must be lowercase and
@@ -109,6 +121,7 @@ primitive types, rather types defined within less. See the LESS documentation fo
 
 #### report
 Choices: `false` `'min'` `'gzip'`
+
 Default: `false`
 
 Either do not report anything, report only minification result, or report minification and gzip results. This is useful to see exactly how well Less is performing, but using `'gzip'` can add 5-10x runtime task execution.
@@ -123,30 +136,35 @@ Gzipped:  20084 bytes.
 
 #### sourceMap
 Type: `Boolean`
+
 Default: `false`
 
 Enable source maps.
 
 #### sourceMapFilename
 Type: `String`
+
 Default: none
 
 Write the source map to a separate file with the given filename.
 
 #### sourceMapBasepath
 Type: `String`
+
 Default: none
 
 Sets the base path for the less file paths in the source map.
 
 #### sourceMapRootpath
 Type: `String`
+
 Default: none
 
 Adds this path onto the less file paths in the source map.
 
 #### outputSourceFiles
 Type: `Boolean`
+
 Default: false
 
 Puts the less files into the map instead of referencing them.
@@ -202,4 +220,4 @@ less: {
 
 Task submitted by [Tyler Kellen](http://goingslowly.com/)
 
-*This file was generated on Thu Nov 14 2013 09:29:34.*
+*This file was generated on Thu Nov 14 2013 19:06:55.*

--- a/docs/less-options.md
+++ b/docs/less-options.md
@@ -2,24 +2,28 @@
 
 ## paths
 Type: `String|Array`
+
 Default: Directory of input file.
 
 Specifies directories to scan for @import directives when parsing. Default value is the directory of the source, which is probably what you want.
 
 ## compress
 Type: `Boolean`
+
 Default: `false`
 
 Compress output by removing some whitespaces.
 
 ## cleancss
 Type: `Boolean`
+
 Default: `false`
 
 Compress output using [clean-css](https://npmjs.org/package/clean-css).
 
 ## ieCompat
 Type: `Boolean`
+
 Default: `true`
 
 Enforce the css output is compatible with Internet Explorer 8.
@@ -28,36 +32,42 @@ For example, the [data-uri](https://github.com/cloudhead/less.js/pull/1086) func
 
 ## optimization
 Type: `Integer`
+
 Default: `null`
 
 Set the parser's optimization level. The lower the number, the less nodes it will create in the tree. This could matter for debugging, or if you want to access the individual nodes in the tree.
 
 ## strictImports
 Type: `Boolean`
+
 Default: `false`
 
 Force evaluation of imports.
 
 ## strictMath
 Type: `Boolean`
+
 Default: `false`
 
 When enabled, math is required to be in parenthesis.
 
 ## strictUnits
 Type: `Boolean`
+
 Default: `false`
 
 When enabled, less will validate the units used (e.g. 4px/2px = 2, not 2px and 4em/2px throws an error).
 
 ## syncImport
 Type: `Boolean`
+
 Default: `false`
 
 Read @import'ed files synchronously from disk.
 
 ## dumpLineNumbers
 Type: `String`
+
 Default: `false`
 
 Configures -sass-debug-info support.
@@ -66,12 +76,14 @@ Accepts following values: `comments`, `mediaquery`, `all`.
 
 ## relativeUrls
 Type: `Boolean`
+
 Default: `false`
 
 Rewrite urls to be relative. false: do not modify urls.
 
 ## customFunctions
 Type: `Object`
+
 Default: none
 
 Define custom functions to be available within your LESS stylesheets. The function's name must be lowercase and
@@ -81,6 +93,7 @@ primitive types, rather types defined within less. See the LESS documentation fo
 
 ## report
 Choices: `false` `'min'` `'gzip'`
+
 Default: `false`
 
 Either do not report anything, report only minification result, or report minification and gzip results. This is useful to see exactly how well Less is performing, but using `'gzip'` can add 5-10x runtime task execution.
@@ -95,30 +108,35 @@ Gzipped:  20084 bytes.
 
 ## sourceMap
 Type: `Boolean`
+
 Default: `false`
 
 Enable source maps.
 
 ## sourceMapFilename
 Type: `String`
+
 Default: none
 
 Write the source map to a separate file with the given filename.
 
 ## sourceMapBasepath
 Type: `String`
+
 Default: none
 
 Sets the base path for the less file paths in the source map.
 
 ## sourceMapRootpath
 Type: `String`
+
 Default: none
 
 Adds this path onto the less file paths in the source map.
 
 ## outputSourceFiles
 Type: `Boolean`
+
 Default: false
 
 Puts the less files into the map instead of referencing them.


### PR DESCRIPTION
Using linefeed instead of the 2 spaces at the end of line, which were prone to misunderstanding with first-time contributors like me (and automatic stripping in some editors).
