### PR TITLE
Use output file with .map extension appended if sourceMapFilename==true.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,13 +116,23 @@ module.exports = function(grunt) {
         src: 'test/fixtures/style3.less',
         dest: 'tmp/sourceMap.css',
       },
-      sourceMapFilename: {
+      sourceMapFilenameDefault: {
         options: {
           sourceMap: true,
-          sourceMapFilename: 'tmp/sourceMapFilename.css.map'
+          sourceMapFilename: true
+        },
+        files: {
+          'tmp/sourceMapFilenameDefault1.css': 'test/fixtures/style3.less',
+          'tmp/sourceMapFilenameDefault2.css': 'test/fixtures/style4.less',
+        },
+      },
+      sourceMapFilenameCustom: {
+        options: {
+          sourceMap: true,
+          sourceMapFilename: 'tmp/sourceMapFilenameCustomXXX.css.map'
         },
         src: 'test/fixtures/style3.less',
-        dest: 'tmp/sourceMapFilename.css',
+        dest: 'tmp/sourceMapFilenameCustom.css',
       },
       sourceMapBasepath: {
         options: {

--- a/README.md
+++ b/README.md
@@ -142,11 +142,12 @@ Default: `false`
 Enable source maps.
 
 #### sourceMapFilename
-Type: `String`
+Type: `String`, or `Boolean`
 
-Default: none
+Default: none (source map is appended to output file)
 
-Write the source map to a separate file with the given filename.
+Write the source map to a separate file with the given filename,
+or the output filename with `.map` extension appended if `true` is given.
 
 #### sourceMapBasepath
 Type: `String`
@@ -220,4 +221,4 @@ less: {
 
 Task submitted by [Tyler Kellen](http://goingslowly.com/)
 
-*This file was generated on Thu Nov 14 2013 19:06:55.*
+*This file was generated on Thu Nov 14 2013 20:18:26.*

--- a/docs/less-options.md
+++ b/docs/less-options.md
@@ -114,11 +114,12 @@ Default: `false`
 Enable source maps.
 
 ## sourceMapFilename
-Type: `String`
+Type: `String`, or `Boolean`
 
-Default: none
+Default: none (source map is appended to output file)
 
-Write the source map to a separate file with the given filename.
+Write the source map to a separate file with the given filename,
+or the output filename with `.map` extension appended if `true` is given.
 
 ## sourceMapBasepath
 Type: `String`

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -56,7 +56,7 @@ module.exports = function(grunt) {
 
       var compiledMax = [], compiledMin = [];
       grunt.util.async.concatSeries(files, function(file, next) {
-        compileLess(file, options, function(css, err) {
+        compileLess(file, destFile, options, function(css, err) {
           if (!err) {
             if (css.max) {
               compiledMax.push(css.max);
@@ -67,8 +67,12 @@ module.exports = function(grunt) {
             nextFileObj(err);
           }
         }, function (sourceMapContent) {
-          grunt.file.write(options.sourceMapFilename, sourceMapContent);
-          grunt.log.writeln('File ' + options.sourceMapFilename.cyan + ' created.');
+          var sourceMapFilename = options.sourceMapFilename;
+          if (sourceMapFilename === true) {
+            sourceMapFilename = destFile + '.map';
+          }
+          grunt.file.write(sourceMapFilename, sourceMapContent);
+          grunt.log.writeln('File ' + sourceMapFilename.cyan + ' created.');
         });
       }, function() {
         if (compiledMin.length < 1) {
@@ -89,7 +93,7 @@ module.exports = function(grunt) {
     }, done);
   });
 
-  var compileLess = function(srcFile, options, callback, sourceMapCallback) {
+  var compileLess = function(srcFile, destFile, options, callback, sourceMapCallback) {
     options = grunt.util._.extend({filename: srcFile}, options);
     options.paths = options.paths || [path.dirname(srcFile)];
 
@@ -117,6 +121,9 @@ module.exports = function(grunt) {
 
       var minifyOptions = grunt.util._.pick(options, lessOptions.render);
 
+      if (minifyOptions.sourceMap && minifyOptions.sourceMapFilename === true) {
+        minifyOptions.sourceMapFilename = destFile + '.map';
+      }
       if (minifyOptions.sourceMapFilename) {
         minifyOptions.writeSourceMap = sourceMapCallback;
       }

--- a/test/fixtures/style4.less
+++ b/test/fixtures/style4.less
@@ -1,0 +1,4 @@
+#footer {
+  color: #488;
+  background: #344;
+}

--- a/test/less_test.js
+++ b/test/less_test.js
@@ -78,11 +78,27 @@ exports.less = {
 
     test.done();
   },
-  sourceMapFilename: function(test) {
+  sourceMapFilenameDefault1: function(test) {
     test.expect(1);
 
-    var sourceMap = grunt.file.readJSON('tmp/sourceMapFilename.css.map');
-    test.equal(sourceMap.sources[0], 'test/fixtures/style3.less', 'should generate a sourceMap with the less file reference.');
+    var sourceMap = grunt.file.readJSON('tmp/sourceMapFilenameDefault1.css.map');
+    test.equal(sourceMap.sources[0], 'test/fixtures/style3.less', 'should generate a sourceMap with default name and the less file reference.');
+
+    test.done();
+  },
+  sourceMapFilenameDefault2: function(test) {
+    test.expect(1);
+
+    var sourceMap = grunt.file.readJSON('tmp/sourceMapFilenameDefault2.css.map');
+    test.equal(sourceMap.sources[0], 'test/fixtures/style4.less', 'should generate a sourceMap with default name and the less file reference.');
+
+    test.done();
+  },
+  sourceMapFilenameCustom: function(test) {
+    test.expect(1);
+
+    var sourceMap = grunt.file.readJSON('tmp/sourceMapFilenameCustomXXX.css.map');
+    test.equal(sourceMap.sources[0], 'test/fixtures/style3.less', 'should generate a sourceMap with custom name and the less file reference.');
 
     test.done();
   },


### PR DESCRIPTION
Same functionality as in less if --sourcemap filename is omitted ... https://github.com/less/less.js/blob/master/lib/less/lessc_helper.js#L42

Esp. useful when generating multiple css files in single task, see `sourceMapFilenameDefault` test in `Gruntfile.js`.
