### PR TITLE
rootpath header typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Default: Directory of input file.
 
 Specifies directories to scan for @import directives when parsing. Default value is the directory of the source, which is probably what you want.
 
-### rootpath
+#### rootpath
 Type: `String`
 
 Default: `""`


### PR DESCRIPTION
It exists here too. I thought it'd be a file include, but oh well.. manually fixed
