### PR TITLE
normalize line endings on tests...

### DIFF
--- a/test/less_test.js
+++ b/test/less_test.js
@@ -3,16 +3,20 @@
 var grunt = require('grunt');
 var fs = require('fs');
 
+var readFile = function(src) {
+  return grunt.file.read(src).replace(/\r\n|\n\r/g, '\n');
+};
+
 exports.less = {
   compile: function(test) {
     test.expect(2);
 
-    var actual = grunt.file.read('tmp/less.css');
-    var expected = grunt.file.read('test/expected/less.css');
+    var actual = readFile('tmp/less.css');
+    var expected = readFile('test/expected/less.css');
     test.equal(expected, actual, 'should compile less, with the ability to handle imported files from alternate include paths');
 
-    actual = grunt.file.read('tmp/concat.css');
-    expected = grunt.file.read('test/expected/concat.css');
+    actual = readFile('tmp/concat.css');
+    expected = readFile('test/expected/concat.css');
     test.equal(expected, actual, 'should concat output when passed an array');
 
     test.done();
@@ -20,8 +24,8 @@ exports.less = {
   compress: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/compress.css');
-    var expected = grunt.file.read('test/expected/compress.css');
+    var actual = readFile('tmp/compress.css');
+    var expected = readFile('test/expected/compress.css');
     test.equal(expected, actual, 'should compress output when compress option is true');
 
     test.done();
@@ -29,8 +33,8 @@ exports.less = {
   nopaths: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/nopaths.css');
-    var expected = grunt.file.read('test/expected/nopaths.css');
+    var actual = readFile('tmp/nopaths.css');
+    var expected = readFile('test/expected/nopaths.css');
     test.equal(expected, actual, 'should default paths to the dirname of the less file');
 
     test.done();
@@ -38,12 +42,12 @@ exports.less = {
   cleancss: function(test) {
     test.expect(2);
 
-    var actual = grunt.file.read('tmp/cleancss.css');
-    var expected = grunt.file.read('test/expected/cleancss.css');
+    var actual = readFile('tmp/cleancss.css');
+    var expected = readFile('test/expected/cleancss.css');
     test.equal(expected, actual, 'should cleancss output when cleancss option is true');
 
-    actual = grunt.file.read('tmp/cleancssReport.css');
-    expected = grunt.file.read('test/expected/cleancssReport.css');
+    actual = readFile('tmp/cleancssReport.css');
+    expected = readFile('test/expected/cleancssReport.css');
     test.equal(expected, actual, 'should cleancss output when cleancss option is true and concating is enable');
 
     test.done();
@@ -51,12 +55,12 @@ exports.less = {
   ieCompat: function(test) {
     test.expect(2);
 
-    var actual = grunt.file.read('tmp/ieCompatFalse.css');
-    var expected = grunt.file.read('test/expected/ieCompatFalse.css');
+    var actual = readFile('tmp/ieCompatFalse.css');
+    var expected = readFile('test/expected/ieCompatFalse.css');
     test.equal(expected, actual, 'should generate data-uris no matter the size when ieCompat option is true');
 
-    actual = grunt.file.read('tmp/ieCompatTrue.css');
-    expected = grunt.file.read('test/expected/ieCompatTrue.css');
+    actual = readFile('tmp/ieCompatTrue.css');
+    expected = readFile('test/expected/ieCompatTrue.css');
     test.equal(expected, actual, 'should generate data-uris only when under the 32KB mark for Internet Explorer 8');
 
     test.done();
@@ -64,8 +68,8 @@ exports.less = {
   variablesAsLess: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/variablesAsLess.css');
-    var expected = grunt.file.read('test/expected/variablesAsLess.css');
+    var actual = readFile('tmp/variablesAsLess.css');
+    var expected = readFile('test/expected/variablesAsLess.css');
     test.equal(expected, actual, 'should process css files imported less files');
 
     test.done();
@@ -73,7 +77,7 @@ exports.less = {
   sourceMap: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/sourceMap.css');
+    var actual = readFile('tmp/sourceMap.css');
     test.ok(actual.indexOf('/*# sourceMappingURL=') !== -1, 'compiled file should include a source map.');
 
     test.done();
@@ -89,7 +93,7 @@ exports.less = {
   sourceMapURL: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/sourceMapWithCustomURL.css');
+    var actual = readFile('tmp/sourceMapWithCustomURL.css');
     test.ok(actual.indexOf('/*# sourceMappingURL=custom/url/for/sourceMap.css.map') !== -1, 'compiled file should have a custom source map URL.');
     test.done();
   },
@@ -112,7 +116,7 @@ exports.less = {
   sourceMapLessInline: function(test) {
     test.expect(1);
 
-    var expected = grunt.file.read('test/fixtures/style3.less');
+    var expected = readFile('test/fixtures/style3.less');
     var sourceMap = grunt.file.readJSON('tmp/sourceMapLessInline.css.map');
     test.equal(sourceMap.sourcesContent[0], expected, 'should put the less file into the generated sourceMap instead of referencing them.');
 
@@ -121,8 +125,8 @@ exports.less = {
   customFunctions: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/customFunctions.css');
-    var expected = grunt.file.read('test/expected/customFunctions.css');
+    var actual = readFile('tmp/customFunctions.css');
+    var expected = readFile('test/expected/customFunctions.css');
     test.equal(expected, actual, 'should execute custom functions');
 
     test.done();


### PR DESCRIPTION
to prevent tests from failing from carriage returns on windows
