### PR TITLE
Use chalk module to colorize terminal output

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "less": "~1.5.1",
-    "grunt-lib-contrib": "~0.6.1"
+    "grunt-lib-contrib": "~0.6.1",
+    "chalk": "~0.4.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.2",

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -14,6 +14,7 @@ module.exports = function(grunt) {
   var contrib = require('grunt-lib-contrib').init(grunt);
 
   var path = require('path');
+  var chalk = require('chalk');
   var less = require('less');
 
   var lessOptions = {
@@ -67,7 +68,7 @@ module.exports = function(grunt) {
           }
         }, function (sourceMapContent) {
           grunt.file.write(options.sourceMapFilename, sourceMapContent);
-          grunt.log.writeln('File ' + options.sourceMapFilename.cyan + ' created.');
+          grunt.log.writeln('File ' + chalk.cyan(options.sourceMapFilename) + ' created.');
         });
       }, function() {
         if (compiledMin.length < 1) {
@@ -75,7 +76,7 @@ module.exports = function(grunt) {
         } else {
           var min = compiledMin.join(options.cleancss ? '' : grunt.util.normalizelf(grunt.util.linefeed));
           grunt.file.write(destFile, min);
-          grunt.log.writeln('File ' + destFile.cyan + ' created.');
+          grunt.log.writeln('File ' + chalk.cyan(destFile) + ' created.');
 
           // ...and report some size information.
           if (options.report) {


### PR DESCRIPTION
Add [chalk](https://github.com/sindresorhus/chalk) as a dependency and use it to colorize terminal output.
