### PR TITLE
Added support for relative sourceMapBasepath. 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -142,6 +142,18 @@ module.exports = function(grunt) {
         src: 'test/fixtures/style3.less',
         dest: 'tmp/sourceMapBasepath.css',
       },
+      sourceMapBasepathFunction: {
+        options: {
+          sourceMap: true,
+          sourceMapFilename: 'tmp/sourceMapBasepath.css.map',
+          sourceMapBasepath: function(dest) {
+            var path = require('path');
+            return path.dirname(dest);
+          }
+        },
+        src: 'test/fixtures/style3.less',
+        dest: 'tmp/sourceMapBasepath.css',
+      },
       sourceMapRootpath: {
         options: {
           sourceMap: true,

--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ Default: none
 Override the default url that points to the sourcemap from the compiled css file.
 
 #### sourceMapBasepath
-Type: `String`
+Type: `String|Function`
 
 Default: none
 
-Sets the base path for the less file paths in the source map.
+Sets the base path for the less file paths in the source map. If a function is provided, the source file is passed as the argument and the return value will be used as the base path.
 
 #### sourceMapRootpath
 Type: `String`

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -93,6 +93,16 @@ module.exports = function(grunt) {
     options = grunt.util._.extend({filename: srcFile}, options);
     options.paths = options.paths || [path.dirname(srcFile)];
 
+    if (typeof options.sourceMapBasepath === 'function') {
+      try {
+        options.sourceMapBasepath = options.sourceMapBasepath(srcFile);
+      } catch (e) {
+        var err = new Error('Generating sourceMapBasepath failed.');
+        err.origError = e;
+        grunt.fail.warn(err);
+      }
+    }
+
     var css;
     var srcCode = grunt.file.read(srcFile);
 

--- a/test/less_test.js
+++ b/test/less_test.js
@@ -101,6 +101,14 @@ exports.less = {
 
     test.done();
   },
+  sourceMapBasepathFunction: function(test) {
+    test.expect(1);
+
+    var sourceMap = grunt.file.readJSON('tmp/sourceMapBasepath.css.map');
+    test.equal(sourceMap.sources[0], 'style3.less', 'should use the basepath for the less file references in the generated sourceMap.');
+
+    test.done();
+  },
   sourceMapRootpath: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
When sourceMapBasepath is `.`, the path to the less file is used.
