### PR TITLE
change to async call so stack doesn't grow forever

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -62,7 +62,7 @@ module.exports = function(grunt) {
               compiledMax.push(css.max);
             }
             compiledMin.push(css.min);
-            next();
+            process.nextTick(next);
           } else {
             nextFileObj(err);
           }


### PR DESCRIPTION
Currently the call to `next()` keeps everything from the previous compilations on the stack, which can cause the process to take up HUGE amounts of memory (got up to 1.5gb on my machine). This change simply schedules the next function to be run in the next iteration of the event loop, allowing the current context to be cleaned up.
