### PR TITLE
Enforce unix line endings for CSS files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.css   text eol=lf


### PR DESCRIPTION
This fixes test failures on Windows with `autocrlf` set to `true`.
