### PR TITLE
Update less.js

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -155,7 +155,7 @@ module.exports = function(grunt) {
     var pairs = _.pairs(options);
     var output = '';
     pairs.forEach(function(pair) {
-      output += '@' + pair[0] + ':' + pair[1] + ';';
+      output += '@' + pair[0] + ': "' + pair[1] + '";';
     });
     return output;
   };


### PR DESCRIPTION
Added quotes around the outputted variable value when using the modifyVars option to prevent a less syntax error from being thrown.
