### PR TITLE
Added example with files-array notation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,27 @@ less: {
   }
 }
 ```
-
+If what you want is to compile *all* the .less files from a given directory, you may also use the "files-array" syntax :
+````js
+less: {
+  development: {
+    options: {
+      //  [...]
+    },
+    files: [
+      {
+         expand: true,
+         cwd: 'path/to/source/directory',
+         src: ['*.less'],
+         dest: 'path/to/result/directory',
+         ext: '.css'
+      }
+    ]
+  }
+  // [...]
+}
+  
+```
 
 ## Release History
 


### PR DESCRIPTION
Hi!

I'd been looking for some time for a way of compiling all less files from a given directory, until I found the solution [here on StackOverflow](http://stackoverflow.com/questions/15597839/grunt-replace-all-less-files-into-css-files/15600742#15600742).

I reckon it's common functionality, so I think it'd be good to add it to the README.

Cheers,

Val Waeselynck
