### PR TITLE
Fix bug: if the end line is comments, the modifyVars option will have no effect

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -115,7 +115,10 @@ module.exports = function(grunt) {
     // Properties under options.modifyVars are appended as less variables
     // to override global variables.
     var modifyVarsOutput = parseVariableOptions(options['modifyVars']);
-    srcCode += modifyVarsOutput;
+    if (modifyVarsOutput) {
+      srcCode += '\n';
+      srcCode += modifyVarsOutput;
+    }
 
     parser.parse(srcCode, function(parse_err, tree) {
       if (parse_err) {

--- a/test/fixtures/modifyVars.less
+++ b/test/fixtures/modifyVars.less
@@ -5,3 +5,4 @@
   padding: @customPadding;
   background: url('@{imgPath}/nice-kitty.jpg')
 }
+// comments


### PR DESCRIPTION
If the end line is comments, the modifyVars option will have no effect.
