### PR TITLE
Interims workaround for #185

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "less": "^1.7.0",
+    "less": "1.7.0",
     "chalk": "^0.4.0",
     "maxmin": "^0.1.0",
     "lodash": "^2.4.1",


### PR DESCRIPTION
grunt-contrib-less silently block/fails since the less package was upgraded to 1.7.1

As I'm unable to debug/solve the root issue, this patch workarounds the issue by pinning down the less version.
