### PR TITLE
Ensure banner only outputs on the first file in a series

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -58,14 +58,12 @@ module.exports = function(grunt) {
       }
 
       var compiledMax = [], compiledMin = [];
-      var index = 0;
+      var i = 0;
 
       async.concatSeries(files, function(file, next) {
-        if (index > 0) {
-          options.banner = ''
+        if (i++ > 0) {
+          options.banner = '';
         }
-
-        index++;
 
         compileLess(file, options, function(css, err) {
           if (!err) {


### PR DESCRIPTION
This pull request fixes #200 where the banner would be repeated across multiple sources into a single destination. It resets the banner option in the loop but there could be other approaches.
