### PR TITLE
import (once) does not work as expected when specifying multiple src fil...

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -64,9 +64,9 @@ module.exports = function(grunt) {
           if(!css){
               grunt.log.warn('Destination not written because compiled files were empty.');
           } else {
-            var max = css.max;
-            var min = css.min;
-            grunt.file.write(destFile, min);
+            var max = css.max||'';
+            var min = css.min||'';
+            grunt.file.write(destFile, css.min);
             grunt.log.writeln('File ' + chalk.cyan(destFile) + ' created: ' + maxmin(max, min, options.report === 'gzip'));
           }
 

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -64,8 +64,8 @@ module.exports = function(grunt) {
           if(!css){
               grunt.log.warn('Destination not written because compiled files were empty.');
           } else {
-            var max = css.max||'';
-            var min = css.min||'';
+            var max = css.max || '';
+            var min = css.min || '';
             grunt.file.write(destFile, css.min);
             grunt.log.writeln('File ' + chalk.cyan(destFile) + ' created: ' + maxmin(max, min, options.report === 'gzip'));
           }
@@ -77,7 +77,6 @@ module.exports = function(grunt) {
           grunt.log.writeln('File ' + chalk.cyan(options.sourceMapFilename) + ' created.');
         });
 
-      // done();
     }, done);
   });
 

--- a/test/expected/concat.css
+++ b/test/expected/concat.css
@@ -1,11 +1,9 @@
 body {
   color: #ffffff;
 }
-
 #header {
   background: #ffffff;
 }
-
 #footer {
   color: #377;
   background: #233;


### PR DESCRIPTION
...es to a single dest.  Each dest should be run through the less parser as one unit, concatenating the src files before hand. addresses #203

This change modifies the task by sending the pre-concatenated files through the parse in one chunk, rather than separate files with a new parser instance.

Multiple dest files will be processed separately.

A single source-map is created as well for the multiple src files, so this may be a possible fix for #89 as well.