### PR TITLE
Bumping version of less, as new version contain important bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "async": "^0.2.10",
     "chalk": "^0.5.1",
-    "less": "^1.7.2",
+    "less": "^1.7.4",
     "lodash": "^2.4.1",
     "maxmin": "^0.1.0"
   },


### PR DESCRIPTION
We experienced quite often issue in less mentioned in following thread: https://github.com/gruntjs/grunt-contrib-less/issues/166 so I decided to upgrade this dependency
