### PR TITLE
Added cleancssOptions as a option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,6 +83,16 @@ module.exports = function(grunt) {
           'tmp/cleancss.css': ['test/fixtures/style.less']
         }
       },
+      cleancssOptions: {
+        options: {
+          paths: ['test/fixtures/include'],
+          cleancss: true,
+          cleancssOptions: {keepSpecialComments: 0}
+        },
+        files: {
+          'tmp/cleancssOptions.css': ['test/fixtures/cleancssOptions.less']
+        }
+      },
       ieCompatTrue: {
         options: {
           paths: ['test/fixtures/include'],

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Default: `false`
 
 Compress output using [clean-css](https://npmjs.org/package/clean-css).
 
+#### cleancssOptions
+Type: `Object`
+
+Default: none
+
 #### ieCompat
 Type: `Boolean`
 

--- a/docs/less-options.md
+++ b/docs/less-options.md
@@ -30,6 +30,11 @@ Default: `false`
 
 Compress output using [clean-css](https://npmjs.org/package/clean-css).
 
+## cleancssOptions
+Type: `Object`
+
+Default: none
+
 ## ieCompat
 Type: `Boolean`
 

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
   var lessOptions = {
     parse: ['paths', 'optimization', 'filename', 'strictImports', 'syncImport', 'dumpLineNumbers', 'relativeUrls',
       'rootpath'],
-    render: ['compress', 'cleancss', 'ieCompat', 'strictMath', 'strictUnits', 'urlArgs',
+    render: ['compress', 'cleancss', 'cleancssOptions', 'ieCompat', 'strictMath', 'strictUnits', 'urlArgs',
        'sourceMap', 'sourceMapFilename', 'sourceMapURL', 'sourceMapBasepath', 'sourceMapRootpath', 'outputSourceFiles']
   };
 

--- a/test/expected/cleancssOptions.css
+++ b/test/expected/cleancssOptions.css
@@ -1,0 +1,1 @@
+body{color:#fff}

--- a/test/fixtures/cleancssOptions.less
+++ b/test/fixtures/cleancssOptions.less
@@ -1,0 +1,7 @@
+/*!
+ * Comment
+ */
+@import "variables.less";
+body {
+  color: @color;
+}

--- a/test/less_test.js
+++ b/test/less_test.js
@@ -53,7 +53,7 @@ exports.less = {
     test.done();
   },
   cleancss: function(test) {
-    test.expect(2);
+    test.expect(3);
 
     var actual = read('tmp/cleancss.css');
     var expected = read('test/expected/cleancss.css');
@@ -62,6 +62,10 @@ exports.less = {
     actual = read('tmp/cleancssReport.css');
     expected = read('test/expected/cleancssReport.css');
     test.equal(expected, actual, 'should cleancss output when cleancss option is true and concating is enable');
+
+    actual = read('tmp/cleancssOptions.css');
+    expected = read('test/expected/cleancssOptions.css');
+    test.equal(expected, actual, 'should cleancss output when cleancss option is true and keepSpecialComments is disable');
 
     test.done();
   },


### PR DESCRIPTION
I needed this for keepSpecialComments. And I think it's better to allow any options to cleancss than implemented it one by one.

This feature was requested for example here #131 and #115 and #103.
