### PR TITLE
Fixed issue where source map filename was always required

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -76,8 +76,9 @@ module.exports = function(grunt) {
             nextFileObj(err);
           }
         }, function (sourceMapContent) {
-          grunt.file.write(options.sourceMapFilename, sourceMapContent);
-          grunt.log.writeln('File ' + chalk.cyan(options.sourceMapFilename) + ' created.');
+          var sourceMapPath = (options.sourceMapFilename) ? options.sourceMapFilename : destFile + '.map';
+          grunt.file.write(sourceMapPath, sourceMapContent);
+          grunt.log.writeln('File ' + chalk.cyan(sourceMapPath) + ' created.');
         });
       }, function() {
         if (compiledMin.length < 1) {
@@ -151,8 +152,12 @@ module.exports = function(grunt) {
 
       var minifyOptions = _.pick(options, lessOptions.render);
 
-      if (minifyOptions.sourceMapFilename) {
+      if (minifyOptions.sourceMap) {
         minifyOptions.writeSourceMap = sourceMapCallback;
+
+        if (!options.sourceMapFilename) {
+          minifyOptions.sourceMapFilename = path.basename(srcFile) + '.map';
+        }
       }
 
       try {


### PR DESCRIPTION
A single file name was explicitly checked for, even when the grunt config was setup to parse multiple files.

Now source maps can be generated per file.

Example Grunt configuration, where source maps are now generated per file:

``` javascript
   less: {
      dist: {
         options: {
            sourceMap: true,
            outputSourceFiles: true
         },
         files: [
            {
               expand: true,
               cwd: '<%= project.app %>/less/',
               src: ['*.less'],
               dest: '<%= project.build %>/css/',
               ext: '.css'
            }
         ]
      }
```
