### PR TITLE
Tweak AppVeyor testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,29 @@
-# appveyor file
+# AppVeyor file
 # http://www.appveyor.com/docs/appveyor-yml
 project_id: "e3aa4d07xe4w4u05"
 
-# build version format
+# Build version format
 version: "{build}"
 
-# fix lineendings in Windows
+# Fix line endings in Windows
 init:
-  - git config --global core.autocrlf input
+  - git config --global core.autocrlf true
 
-# what combinations to test
+# What combinations to test
 environment:
   matrix:
     - nodejs_version: 0.10
 
-# Get the latest stable version of Node 0.STABLE.latest
 install:
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
   - npm install -g grunt-cli
   - npm install
 
 build: off
 
 test_script:
-  - node --version
-  - npm --version
-  - ps: grunt test --no-color # PowerShell
-  - cmd: grunt test --no-color
+  - node --version && npm --version
+  - npm test
+
+cache:
+  - node_modules                                        # local npm modules
+  - C:\Users\appveyor\AppData\Roaming\npm\node_modules  # global npm modules


### PR DESCRIPTION
- changed `autocrlf` to `true`
- ~~changed the badges to SVG~~ submitted a patch upstream for this, see https://github.com/gruntjs/grunt-contrib-internal/pull/16
- enable caching

Note that this has reduced the build time from around 4 min 20 sec to 1 min 25 sec.

/CC @gruntjs/contrib-less 

P.S. I would backport this for the other contrib plugins, but I don't have access there.
