### PR TITLE
options.filename is normalized

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -146,6 +146,8 @@ module.exports = function(grunt) {
       });
     }
 
+    options.filename = path.resolve(options.filename);
+    
     return less.render(srcCode, options)
       .catch(function(err) {
         lessError(err, srcFile);


### PR DESCRIPTION
It converts `/` to `\\` on Windows. Without it  `relativeUrls` is not working…

I am not sure how to test it.