### PR TITLE
sourcemaps with multiple sources

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -223,6 +223,14 @@ module.exports = function(grunt) {
         files: {
           'tmp/modifyVars.css': ['test/fixtures/modifyVars.less']
         }
+      },
+      combineSourceFiles: {
+        options: {
+          combineSourceFiles: true
+        },
+        files: {
+          "tmp/combineSourceFiles.css": ['test/fixtures/include/variables.less','test/fixtures/combineSourceFiles*.less'],
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -145,12 +145,6 @@ Default: none
 
 Adds this path onto the less file paths in the source map.
 
-#### sourceMapFileInline
-Type: `Boolean`  
-Default: false
-
-Puts the map (and any less files) as a base64 data uri into the output css file.      .
-
 #### outputSourceFiles
 Type: `Boolean`  
 Default: false
@@ -166,6 +160,12 @@ Overrides global variables. Equivalent to `--modify-vars='VAR=VALUE'` option in 
 #### banner
 Type: `String`  
 Default: none
+
+#### combineSourceFiles
+Type: `Boolean`  
+Default: false
+
+Combine source files into one 'main' less file before compiling. Used to share variables and mixins across sources and to build an accurate source map across multiple sources.
 
 ### Usage Examples
 
@@ -235,4 +235,4 @@ less: {
 
 Task submitted by [Tyler Kellen](http://goingslowly.com/)
 
-*This file was generated on Tue Dec 23 2014 14:52:06.*
+*This file was generated on Tue Jan 27 2015 10:10:39.*

--- a/docs/less-options.md
+++ b/docs/less-options.md
@@ -132,3 +132,9 @@ Overrides global variables. Equivalent to `--modify-vars='VAR=VALUE'` option in 
 ## banner
 Type: `String`  
 Default: none
+
+## combineSourceFiles
+Type: `Boolean`  
+Default: false
+
+Combine source files into one 'main' less file before compiling. Used to share variables and mixins across sources and to build an accurate source map across multiple sources.

--- a/test/expected/combineSourceFiles.css
+++ b/test/expected/combineSourceFiles.css
@@ -1,0 +1,10 @@
+#bob {
+  /** @color defined in include/variables.less **/
+  color: #ffffff;
+}
+#harold {
+  /** @color defined in include/variables.less **/
+  color: #ffffff;
+  background-color: #ffffff;
+  border: solid 3px blue;
+}

--- a/test/fixtures/combineSourceFiles.less
+++ b/test/fixtures/combineSourceFiles.less
@@ -1,0 +1,4 @@
+#bob{
+  /** @color defined in include/variables.less **/
+  color: @color;
+}

--- a/test/fixtures/combineSourceFilesTwo.less
+++ b/test/fixtures/combineSourceFilesTwo.less
@@ -1,0 +1,5 @@
+#harold{
+  /** @color defined in include/variables.less **/
+  color: @color;
+  .myVaugeMixin();
+}

--- a/test/fixtures/include/variables.less
+++ b/test/fixtures/include/variables.less
@@ -1,1 +1,5 @@
 @color: #ffffff;
+.myVaugeMixin(){
+  background-color: @color;
+  border: solid 3px blue;
+}

--- a/test/less_test.js
+++ b/test/less_test.js
@@ -160,6 +160,15 @@ exports.less = {
 
     test.done();
   },
+  combineSourceFiles: function(test) {
+    test.expect(1);
+
+    var actual = read('tmp/combineSourceFiles.css');
+    var expected = read('test/expected/combineSourceFiles.css');
+    test.equal(expected, actual, 'should combine sources to share variables and mixins');
+
+    test.done();
+  },
   banner: function(test) {
     test.expect(2);
 


### PR DESCRIPTION
I've added an option, combineSourceFiles, which, when set to true, will cause the sources to be compiled "per-destination" allowing mixins and variables to be shared over multiple files.

Setting this will also make source maps work properly over multiple files to a single destination.

original story #89
I think it will fix #196 too.