### PR TITLE
global and modify variables options

### DIFF
--- a/docs/less-options.md
+++ b/docs/less-options.md
@@ -123,11 +123,19 @@ Default: false
 
 Puts the less files into the map instead of referencing them.
 
-## modifyVars
-Type: `Object`  
+#### globalVars
+Type: `JSON Object`  
+Default: none
+
+Defines variables that can be referenced by the file. Equivalent to `--global-vars='VAR=VALUE'` option in less.
+Example: `globalVars: {"color":"red","string":"\"some text\""}`
+
+#### modifyVars
+Type: `JSON Object`  
 Default: none
 
 Overrides global variables. Equivalent to `--modify-vars='VAR=VALUE'` option in less.
+Example: `modifyVars: {"color":"red","string":"\"some text\""}`
 
 ## banner
 Type: `String`  

--- a/docs/less-options.md
+++ b/docs/less-options.md
@@ -123,14 +123,14 @@ Default: false
 
 Puts the less files into the map instead of referencing them.
 
-#### globalVars
+## globalVars
 Type: `JSON Object`  
 Default: none
 
 Defines variables that can be referenced by the file. Equivalent to `--global-vars='VAR=VALUE'` option in less.
 Example: `globalVars: {"color":"red","string":"\"some text\""}`
 
-#### modifyVars
+## modifyVars
 Type: `JSON Object`  
 Default: none
 

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -125,15 +125,6 @@ module.exports = function(grunt) {
 
     var srcCode = grunt.file.read(srcFile);
 
-    // Equivalent to --modify-vars option.
-    // Properties under options.modifyVars are appended as less variables
-    // to override global variables.
-    var modifyVarsOutput = parseVariableOptions(options['modifyVars']);
-    if (modifyVarsOutput) {
-      srcCode += '\n';
-      srcCode += modifyVarsOutput;
-    }
-
     // Load custom functions
     if (options.customFunctions) {
       Object.keys(options.customFunctions).forEach(function(name) {
@@ -151,16 +142,7 @@ module.exports = function(grunt) {
         lessError(err, srcFile);
       });
   };
-
-  var parseVariableOptions = function(options) {
-    var pairs = _.pairs(options);
-    var output = '';
-    pairs.forEach(function(pair) {
-      output += '@' + pair[0] + ':' + pair[1] + ';';
-    });
-    return output;
-  };
-
+  
   var formatLessError = function(e) {
     var pos = '[' + 'L' + e.line + ':' + ('C' + e.column) + ']';
     return e.filename + ': ' + pos + ' ' + e.message;


### PR DESCRIPTION
Cause grunt-contrib-less passes a options object to the less compiler now, it does no have to handle the `modifyVars` itself. For this reason i have remove this from the code and update the README for both the modifyVars and the  globalVars options.
