### PR TITLE
Use `grunt.verbose` instead of logging every created file.

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -65,7 +65,7 @@ module.exports = function(grunt) {
                 sourceMapFilename = destFile + '.map';
               }
               grunt.file.write(sourceMapFilename, output.map);
-              grunt.log.writeln('File ' + chalk.cyan(sourceMapFilename) + ' created.');
+              grunt.verbose.writeln('File ' + chalk.cyan(sourceMapFilename) + ' created.');
             }
             process.nextTick(next);
           },
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
         } else {
           var allCss = compiled.join(options.compress ? '' : grunt.util.normalizelf(grunt.util.linefeed));
           grunt.file.write(destFile, allCss);
-          grunt.log.writeln('File ' + chalk.cyan(destFile) + ' created');
+          grunt.verbose.writeln('File ' + chalk.cyan(destFile) + ' created');
         }
         nextFileObj();
       });


### PR DESCRIPTION
Following unix and [`grunt-contrib-copy`'s lead](https://github.com/gruntjs/grunt-contrib-copy/blob/master/tasks/copy.js#L68), write file creation messages to the verbose log instead of to stdout, which can get very noisy with many files. Continue logging errors to stderr.