### PR TITLE
Do not manually parse/append variable options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -212,6 +212,18 @@ module.exports = function(grunt) {
           'tmp/customFunctions.css': ['test/fixtures/customFunctions.less']
         }
       },
+      globalVars: {
+        options: {
+          globalVars: {
+            // Note the double quotes in 'imgPath'
+            imgPath: '"/right/here"',
+            customPadding: '10px'
+          }
+        },
+        files: {
+          'tmp/globalVars.css': ['test/fixtures/globalVars.less']
+        }
+      },
       modifyVars: {
         options: {
           modifyVars: {

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Adds this path onto the less file paths in the source map.
 Type: `Boolean`  
 Default: false
 
-Puts the map (and any less files) as a base64 data uri into the output css file.      .
+Puts the map (and any less files) as a base64 data uri into the output css file.
 
 #### outputSourceFiles
 Type: `Boolean`  
@@ -157,11 +157,35 @@ Default: false
 
 Puts the less files into the map instead of referencing them.
 
+#### globalVars
+Type: `Object`  
+Default: none
+
+Defines global variables. Equivalent to `--global-vars='VAR=VALUE'` option in less.
+
+##### Example
+
+```js
+globalVars: {
+  color: 'red',
+  string: '"some text"'
+}
+```
+
 #### modifyVars
 Type: `Object`  
 Default: none
 
 Overrides global variables. Equivalent to `--modify-vars='VAR=VALUE'` option in less.
+
+##### Example
+
+```js
+modifyVars: {
+  color: 'red',
+  string: '"some text"'
+}
+```
 
 #### banner
 Type: `String`  

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -141,14 +141,6 @@ module.exports = function(grunt) {
 
     var srcCode = grunt.file.read(srcFile);
 
-    // Equivalent to --modify-vars option.
-    // Properties under options.modifyVars are appended as less variables
-    // to override global variables.
-    var modifyVarsOutput = parseVariableOptions(options.modifyVars);
-    if (modifyVarsOutput) {
-      srcCode += '\n' + modifyVarsOutput;
-    }
-
     // Load custom functions
     if (options.customFunctions) {
       Object.keys(options.customFunctions).forEach(function(name) {
@@ -165,15 +157,6 @@ module.exports = function(grunt) {
       .catch(function(err) {
         lessError(err, srcFile);
       });
-  };
-
-  var parseVariableOptions = function(options) {
-    var pairs = _.pairs(options);
-    var output = '';
-    pairs.forEach(function(pair) {
-      output += '@' + pair[0] + ':' + pair[1] + ';';
-    });
-    return output;
   };
 
   var formatLessError = function(e) {

--- a/test/expected/globalVars.css
+++ b/test/expected/globalVars.css
@@ -1,0 +1,4 @@
+.nice-kitty {
+  padding: 10px;
+  background: url('/right/here/nice-kitty.jpg');
+}

--- a/test/fixtures/globalVars.less
+++ b/test/fixtures/globalVars.less
@@ -1,0 +1,5 @@
+.nice-kitty {
+  padding: @customPadding;
+  background: url('@{imgPath}/nice-kitty.jpg')
+}
+// comments

--- a/test/less_test.js
+++ b/test/less_test.js
@@ -86,6 +86,15 @@ exports.less = {
 
     test.done();
   },
+  globalVars: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/globalVars.css');
+    var expected = grunt.file.read('test/expected/globalVars.css');
+    test.equal(expected, actual, 'should define global variables');
+
+    test.done();
+  },
   modifyVars: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
This is essentially #247 with tests.

Since the options are passed to the LESS compiler, we do not have to parse/append `modifyVars` and `globalVars`.

- Add documentation and example to readme
- Add tests