### PR TITLE
Support of cache.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "async": "^0.9.0",
     "chalk": "^1.0.0",
     "less": "~2.5.0",
-    "lodash": "^3.2.0"
+    "lodash": "^3.2.0",
+    "promise": "^7.0.4"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Hello!
Sorry for my English.

I added support cache per source file. For example twitter boostrap compilation:
![screenshot at 02-03-33](https://cloud.githubusercontent.com/assets/4432904/11698799/70e9164a-9ee2-11e5-96f9-d0f6c0bc804d.png)

Supports two options:

#### cache
Type: `Boolean`
Default: false

Cache in memory. For example can use it in `watch` for tasks with `spawn: false` option.

#### cacheFile
Type: `String`
Default: none

Permanent storage cache.

----

P.S. In my project this reduce compile time from ~15s to ~1s.