### PR TITLE
Fix --force not working

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -75,6 +75,7 @@ module.exports = function(grunt) {
             process.nextTick(next);
           },
           function(err) {
+            lessError(err, file);
             nextFileObj(err);
           });
       }, function() {
@@ -161,10 +162,7 @@ module.exports = function(grunt) {
       });
     }
 
-    return less.render(srcCode, options)
-      .catch(function(err) {
-        lessError(err, srcFile);
-      });
+    return less.render(srcCode, options);
   };
 
   var parseVariableOptions = function(options) {


### PR DESCRIPTION
After recently upgrading from version 0.10 to 1.3.0, I noticed the `--force` grunt option was no longer working. After a short investigation, it turned out that there was a small mistake in the error handling for `less.render`. This should now be fixed with this pull request.

Note that I didn't create any specific tests for this situation, as that would mean the tests themselves would have to be run with `--force`, which seems undesirable. What you can do (for instance) to easily test the fix is removing the closing `}` in `test/fixtures/style.less` and running `grunt less:compile clean --force`. This will _not_ perform the clean in the current 1.3.0 version, but will with the code provided in this pull request.

-- Jimi
