### PR TITLE
Avoid appending empty variable to the global scope

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -251,6 +251,16 @@ module.exports = function(grunt) {
         files: {
           'tmp/modifyVars.css': ['test/fixtures/modifyVars.less']
         }
+      },
+      modifyVarsWithUndefined: {
+        options: {
+          modifyVars: {
+            customColor: undefined
+          }
+        },
+        files: {
+          'tmp/modifyVarsWithUndefined.css': [ 'test/fixtures/modifyVarsWithUndefined.less']
+        }
       }
     },
 

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -192,10 +192,14 @@ module.exports = function(grunt) {
 
   var parseVariableOptions = function(options) {
     var pairs = _.toPairs(options);
-    var output = '';
-    pairs.forEach(function(pair) {
-      output += '@' + pair[0] + ':' + pair[1] + ';';
-    });
+    var output = _.reduce(pairs, function(accumulator, pair) {
+      var variableName = pair[0];
+      var variableValue = pair[1];
+      if (variableValue) {
+        accumulator += '@' + variableName + ':' + variableValue + ';';
+      }
+      return accumulator;
+    }, '');
     return output;
   };
 

--- a/test/expected/modifyVarsWithUndefined.css
+++ b/test/expected/modifyVarsWithUndefined.css
@@ -1,0 +1,3 @@
+.soft-kitty {
+  color: #ffffff;
+}

--- a/test/fixtures/modifyVarsWithUndefined.less
+++ b/test/fixtures/modifyVarsWithUndefined.less
@@ -1,0 +1,4 @@
+@customColor: #ffffff;
+.soft-kitty {
+  color: @customColor;
+}

--- a/test/less_test.js
+++ b/test/less_test.js
@@ -112,6 +112,15 @@ exports.less = {
 
     test.done();
   },
+  modifyVarsWithUndefined: function(test) {
+    test.expect(1);
+
+    var actual = read('tmp/modifyVarsWithUndefined.css');
+    var expected = read('test/expected/modifyVarsWithUndefined.css');
+    test.equal(expected, actual, 'should not override global variables with empty values');
+
+    test.done();
+  },
   sourceMap: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
Sometimes I have a situation like this:

``` js
less: {
  production: {
    options: {
      compress: true,
      modifyVars: {
        'myvar' : grunt.option('myvar') || undefined
      }
    }
  }
}
```

At the moment when the myvar cli param is not passed in, `undefined` is evaluated as a string and in the code I have something like:

``` css
body {
  background: undefined;
}
```

With this pull request I try to avoid to append to the less global scope a variable with an undefined value.
This way can be still resolved by other files in the less code.
