### PR TITLE
Use path.basename for sourceMappingURL.

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -115,7 +115,7 @@ module.exports = function(grunt) {
     }
 
     if (options.sourceMap && !options.sourceMapFileInline && !options.sourceMapFilename) {
-      options.sourceMapFilename = destFile + '.map';
+      options.sourceMapFilename = path.basename(destFile) + '.map';
     }
 
     if (typeof options.sourceMapBasepath === 'function') {


### PR DESCRIPTION
Now the sourceMappingURL will be the same as the CSS file, if not specified.

Fixes #299, fixes #236, fixes #221.

/CC @vladikoff 