### PR TITLE
Updating lodash patch 4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "async": "^2.0.0",
     "chalk": "^1.0.0",
     "less": "^3.0.4",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "grunt": "^1.0.2",


### PR DESCRIPTION
A new version of lodash is available 4.17.11, which is a patch for "security vulnerabilities".