### PR TITLE
Add math option to documentation for Less 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,26 @@ Default: `false`
 
 Force evaluation of imports.
 
-#### strictMath
+#### strictMath (deprecated replaced by `Math`)
 Type: `Boolean`  
 Default: `false`
 
 When enabled, math is required to be in parenthesis.
+
+
+#### math
+Type: `String`
+Default: `parens-division`
+
+Available options:
+
+| Option            | Description                                                                                                                             |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `always`          | Less does math eagerly                                                                                                                  |
+| `parens-division` | No division is performed outside of parens using / operator (but can be "forced" outside of parens with ./ operator - ./ is deprecated) |
+| `parens`          | Parens required for all math expressions                                                                                                |
+| `strict`          | Requires brackets for all operations.                                                                                                   |
+
 
 #### strictUnits
 Type: `Boolean`  

--- a/docs/less-options.md
+++ b/docs/less-options.md
@@ -38,11 +38,25 @@ Default: `false`
 
 Force evaluation of imports.
 
-## strictMath
+## strictMath (deprecated replaced by `Math`)
 Type: `Boolean`  
 Default: `false`
 
 When enabled, math is required to be in parenthesis.
+
+## math
+Type: `String`
+Default: `parens-division`
+
+Available options:
+
+| Option            | Description                                                                                                                             |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `always`          | Less does math eagerly                                                                                                                  |
+| `parens-division` | No division is performed outside of parens using / operator (but can be "forced" outside of parens with ./ operator - ./ is deprecated) |
+| `parens`          | Parens required for all math expressions                                                                                                |
+| `strict`          | Requires brackets for all operations.                                                                                                   |
+
 
 ## strictUnits
 Type: `Boolean`  


### PR DESCRIPTION
After an Update to Less 4.x I had Issues with some divisors and came across Issue #362 . Helped me a lot so thought would be good to have this at least in the docs. Fixes #362 